### PR TITLE
Core: add minimal Constants.phi (+basic lemmas)

### DIFF
--- a/IndisputableMonolith/Core.lean
+++ b/IndisputableMonolith/Core.lean
@@ -22,6 +22,37 @@ lemma all_holds : All := And.intro monotonicity_holds (And.intro symmetry_holds 
 end Invariants
 end Ethics
 
+/‑! #### Constants (minimal) -/
+namespace Constants
+
+/-- Golden ratio φ as a concrete real. -/
+noncomputable def phi : ℝ := (1 + Real.sqrt 5) / 2
+
+lemma phi_pos : 0 < phi := by
+  have h0 : (0 : ℝ) ≤ Real.sqrt 5 := Real.sqrt_nonneg _
+  have h1 : (0 : ℝ) < 1 := by norm_num
+  have hge : (1 : ℝ) ≤ 1 + Real.sqrt 5 := by
+    have := h0
+    have : 1 + 0 ≤ 1 + Real.sqrt 5 := add_le_add_left this 1
+    simpa [one_add, add_comm] using this
+  have : 0 < 1 + Real.sqrt 5 := lt_of_lt_of_le h1 hge
+  have htwo : 0 < (2 : ℝ) := by norm_num
+  simpa [phi] using (div_pos this htwo)
+
+lemma one_lt_phi : 1 < phi := by
+  -- √1 < √5, then add 1 and divide by 2
+  have hroot : Real.sqrt 1 < Real.sqrt 5 := by
+    simpa [Real.sqrt_one] using (Real.sqrt_lt_sqrt (by norm_num) (by norm_num : (1 : ℝ) < 5))
+  have hsum : (1 : ℝ) + 1 < 1 + Real.sqrt 5 := add_lt_add_left hroot 1
+  have htwo : 0 < (2 : ℝ) := by norm_num
+  have := (div_lt_div_of_pos_right hsum htwo)
+  simpa [phi, Real.sqrt_one] using this
+
+lemma phi_ge_one : 1 ≤ phi := le_of_lt one_lt_phi
+lemma phi_ne_zero : phi ≠ 0 := ne_of_gt phi_pos
+
+end Constants
+
 /‑! #### Patterns: complete covers and 8‑tick existence for 3‑bit patterns -/
 namespace Patterns
 


### PR DESCRIPTION
Adds minimal Constants.phi and lemmas (phi_pos, one_lt_phi, phi_ge_one, phi_ne_zero) to Core. Self-contained and preserves green path.