### PR TITLE
Core: units_identity_prop = c*tau0=ell0

### DIFF
--- a/IndisputableMonolith/Core.lean
+++ b/IndisputableMonolith/Core.lean
@@ -171,10 +171,12 @@ end Streams
 
 /‑! #### URC adapters: stable Prop wrappers -/
 
-/-- Units identity (minimal core placeholder). -/
-def units_identity_prop : Prop := True
+/-- Units identity: c·τ0 = ℓ0 for all anchors. -/
+def units_identity_prop : Prop :=
+  ∀ U : Constants.RSUnits, U.c * U.tau0 = U.ell0
 
-lemma units_identity_holds : units_identity_prop := True.intro
+lemma units_identity_holds : units_identity_prop := by
+  intro U; simpa using U.c_ell0_tau0
 
 /-- Eight‑beat existence (period exactly 8). -/
 def eightbeat_prop : Prop := ∃ w : Patterns.CompleteCover 3, w.period = 8


### PR DESCRIPTION
Strengthens units_identity_prop to the concrete anchor relation U.c * U.tau0 = U.ell0. Minimal deps; preserves green path.